### PR TITLE
Add django groups to admin besides local groups

### DIFF
--- a/symfexit/members/admin.py
+++ b/symfexit/members/admin.py
@@ -228,6 +228,3 @@ class UserAdmin(admin.ModelAdmin):
 class LocalGroupAdmin(admin.ModelAdmin):
     exclude = ("permissions",)
     filter_horizontal = ("contact_people",)
-
-
-admin.site.unregister(Group)


### PR DESCRIPTION
These are the builtin django groups that can be used for permissions