### PR TITLE
Use full width form elements on "my details" page

### DIFF
--- a/symfexit/members/forms.py
+++ b/symfexit/members/forms.py
@@ -36,7 +36,7 @@ class UserForm(forms.ModelForm):
         LocalGroup.objects.all(), label=_("Local group"), required=False
     )
     extra_information = forms.CharField(
-        label=_("Extra information"), widget=forms.Textarea, required=False
+        label=_("Extra information"), widget=forms.Textarea(attrs={"rows": 5}), required=False
     )
 
     class Meta:

--- a/symfexit/theme/static_src/src/styles.css
+++ b/symfexit/theme/static_src/src/styles.css
@@ -19,6 +19,12 @@ form {
     input {
       @apply basis-auto grow;
     }
+    select {
+      @apply basis-auto grow;
+    }
+    textarea {
+      @apply basis-auto grow;
+    }
     input[disabled] {
       @apply bg-gray-100;
     }


### PR DESCRIPTION
<img width="1674" height="1598" alt="CleanShot 2025-08-31 at 08 51 21@2x" src="https://github.com/user-attachments/assets/1f20b0cd-0c9d-4e54-9430-e6f01a34003a" />

Widened "extra information" and "local group"