### PR TITLE
Separate management site

### DIFF
--- a/symfexit/adminsite/adminsite.py
+++ b/symfexit/adminsite/adminsite.py
@@ -7,7 +7,7 @@ from django.utils.text import format_lazy
 from django.utils.translation import gettext_lazy as _
 
 
-class MyAdminSite(admin.AdminSite):
+class TenantAdminSite(admin.AdminSite):
     def __init__(self, name: str = "admin") -> None:
         super().__init__(name)
         self.final_catch_all_view = False
@@ -48,7 +48,7 @@ class MyAdminSite(admin.AdminSite):
         return urls
 
 
-admin_site = MyAdminSite(name="symfexit_admin")
+admin_site = TenantAdminSite(name="symfexit_admin")
 
 
 def get_admin_site():

--- a/symfexit/root/management_urls.py
+++ b/symfexit/root/management_urls.py
@@ -1,10 +1,9 @@
 from django.conf import settings
-from django.contrib import admin
 from django.http import HttpResponse
 from django.urls import include, path
 
-# from symfexit.adminsite.admin import admin_site
 from symfexit.root.utils import enable_if
+from symfexit.tenants.adminsite import global_admin
 
 try:
     import django_browser_reload  # noqa
@@ -27,7 +26,7 @@ def regular_urlpatterns():
 urlpatterns = (
     [
         path("healthz", health_check, name="healthz"),
-        path("management/", admin.site.urls),
+        path("management/", global_admin.urls),
     ]
     + enable_if(
         django_browser_reload_enabled,

--- a/symfexit/tenants/admin.py
+++ b/symfexit/tenants/admin.py
@@ -1,9 +1,16 @@
 from django.contrib import admin
 from django_tenants.admin import TenantAdminMixin
 
-from symfexit.tenants.models import Client
+from symfexit.tenants.adminsite import global_admin
+from symfexit.tenants.models import Client, Domain
 
 
-@admin.register(Client)
+class DomainInline(admin.TabularInline):
+    model = Domain
+    extra = 0
+
+
+@admin.register(Client, site=global_admin)
 class ClientAdmin(TenantAdminMixin, admin.ModelAdmin):
     list_display = ("name",)
+    inlines = (DomainInline,)

--- a/symfexit/tenants/adminsite.py
+++ b/symfexit/tenants/adminsite.py
@@ -1,0 +1,10 @@
+from django.contrib.admin import AdminSite
+
+
+class GlobalAdminSite(AdminSite):
+    site_header = "Symfexit Management"
+    site_title = "Symfexit Management Portal"
+    index_title = "Welcome to the Symfexit Management Portal"
+
+
+global_admin = GlobalAdminSite(name="global_admin")

--- a/symfexit/worker/admin.py
+++ b/symfexit/worker/admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 
+from symfexit.tenants.adminsite import global_admin
 from symfexit.worker.models import Task
 
 # Register your models here.
@@ -7,6 +8,19 @@ from symfexit.worker.models import Task
 
 @admin.register(Task)
 class TaskAdmin(admin.ModelAdmin):
+    fields = ("name", "status", "output", "created_at", "picked_up_at", "completed_at")
+    readonly_fields = (
+        "output",
+        "created_at",
+    )
+
+    def get_queryset(self, request):
+        tenant = request.tenant
+        return super().get_queryset(request).filter(tenant=tenant)
+
+
+@admin.register(Task, site=global_admin)
+class GlobalTaskAdmin(admin.ModelAdmin):
     fields = ("name", "status", "output", "created_at", "picked_up_at", "completed_at")
     readonly_fields = (
         "output",

--- a/uv.lock
+++ b/uv.lock
@@ -559,14 +559,12 @@ dependencies = [
     { name = "django-tailwind" },
     { name = "django-tenants" },
     { name = "django-tinymce" },
-    { name = "dotenv" },
     { name = "fontawesomefree" },
     { name = "hashids" },
     { name = "mollie-api-python" },
     { name = "pillow" },
     { name = "psycopg", extra = ["binary", "pool"] },
     { name = "python-magic" },
-    { name = "uvicorn" },
 ]
 
 [package.dev-dependencies]
@@ -574,6 +572,10 @@ dev = [
     { name = "beautifulsoup4" },
     { name = "django-browser-reload" },
     { name = "ruff" },
+]
+prod = [
+    { name = "dotenv" },
+    { name = "uvicorn" },
 ]
 
 [package.metadata]
@@ -587,14 +589,12 @@ requires-dist = [
     { name = "django-tailwind", specifier = "~=4.4" },
     { name = "django-tenants", specifier = "~=3.10.0" },
     { name = "django-tinymce", specifier = "~=5.0" },
-    { name = "dotenv", specifier = ">=0.9.9" },
     { name = "fontawesomefree", specifier = "~=6.2" },
     { name = "hashids", specifier = "~=1.3" },
     { name = "mollie-api-python", specifier = "~=3.6" },
     { name = "pillow", specifier = "~=12.1" },
     { name = "psycopg", extras = ["binary", "pool"], specifier = "~=3.3.2" },
     { name = "python-magic", specifier = ">=0.4.27" },
-    { name = "uvicorn", specifier = ">=0.41.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -602,6 +602,10 @@ dev = [
     { name = "beautifulsoup4", specifier = ">=4.13.5" },
     { name = "django-browser-reload", specifier = ">=1.17.0" },
     { name = "ruff", specifier = ">=0.8.0" },
+]
+prod = [
+    { name = "dotenv", specifier = ">=0.9.9" },
+    { name = "uvicorn", specifier = ">=0.41.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
Makes sure tenants cannot see eachother and eachothers tasks. A global management site can be enabled by adding a domain to the `public` schema