### PR TITLE
Remove unnecessary npm run build from dev container config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,7 +21,7 @@
 	"forwardPorts": [8000, 5432],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "uv sync && echo '[[ -z $VIRTUAL_ENV_PROMPT ]] && source $(pwd)/.venv/bin/activate\nulimit -c 0' | tee -a ~/.bashrc ~/.zshrc; cd symfexit/theme/static_src && npm install && DJANGO_SETTINGS_MODULE=\"symfexit.root.settings\" DJANGO_ADMIN_COMMAND=\"uv run django-admin\"  npm run build"
+	"postCreateCommand": "uv sync && echo '[[ -z $VIRTUAL_ENV_PROMPT ]] && source $(pwd)/.venv/bin/activate\nulimit -c 0' | tee -a ~/.bashrc ~/.zshrc; cd symfexit/theme/static_src && npm install"
 
 	// Configure tool-specific properties.
 	// "customizations": {},


### PR DESCRIPTION
Removes `npm run build` from the dev-container `postCreateCommand`.

This would result in an error upon loading the dev container, as build has not been configured.