### PR TITLE
Fix error on members page when applying filters

### DIFF
--- a/symfexit/members/admin.py
+++ b/symfexit/members/admin.py
@@ -201,9 +201,9 @@ class UserAdmin(admin.ModelAdmin):
             ),
         ] + super().get_urls()
 
-    def lookup_allowed(self, lookup, value):
+    def lookup_allowed(self, lookup, value, request):
         # Don't allow lookups involving passwords.
-        return not lookup.startswith("password") and super().lookup_allowed(lookup, value)
+        return not lookup.startswith("password") and super().lookup_allowed(lookup, value, request)
 
     @method_decorator([sensitive_post_parameters(), csrf_protect])
     def add_view(self, request, form_url="", extra_context=None):

--- a/symfexit/members/tests.py
+++ b/symfexit/members/tests.py
@@ -1,1 +1,30 @@
-# Create your tests here.
+from django.contrib.auth import get_user_model
+from django_tenants.test.cases import FastTenantTestCase
+from django_tenants.test.client import TenantClient
+
+User = get_user_model()
+
+
+class MembersPageTest(FastTenantTestCase):
+    def setUp(self):
+        super().setUp()
+        self.client = TenantClient(self.tenant)
+        # Log in a test user
+        self.client.force_login(User.objects.create_superuser(email="testuser@example.com"))
+
+    def test_members_page_loads(self):
+        response = self.client.get("/admin/members/member/")
+        self.assertEqual(response.status_code, 200)
+
+    def test_members_filters_loads(self):
+        response = self.client.get(
+            "/admin/members/member/",
+            {
+                "cadre__exact": 1,
+                "is_active": "N",
+                "is_staff__exact": 0,
+                "is_superuser__exact": 1,
+                "permission_group": 1,
+            },
+        )
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
There would occur an error because of mismatched parameters, which has been fixed.

Two basic tests have also been written for the `/admin/members/member`-page.