### PR TITLE
277/to many relationship

### DIFF
--- a/symfexit/events/admin.py
+++ b/symfexit/events/admin.py
@@ -2,12 +2,21 @@ from django.contrib import admin
 from django.utils.html import format_html, format_html_join
 
 from symfexit.events.models import Event
+from symfexit.root.export.mixin import ExportMixin
 
 
 @admin.register(Event)
-class EventsAdmin(admin.ModelAdmin):
+class EventsAdmin(ExportMixin, admin.ModelAdmin):
     readonly_fields = ("attendees_display",)
     list_display = ("event_name", "event_date", "event_end", "event_organiser")
+
+    export_fields = (
+        "event_name",
+        "event_date",
+        "event_end",
+        "event_organiser",
+        ("attendees", ["first_name", "last_name", "local_group_name"]),
+    )
 
     def attendees_display(self, obj):
         attendees = obj.attendees.all().order_by("email")

--- a/symfexit/members/locale/nl/LC_MESSAGES/django.po
+++ b/symfexit/members/locale/nl/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-19 13:22+0200\n"
+"POT-Creation-Date: 2026-07-19 13:36+0200\n"
 "PO-Revision-Date: 2026-06-07 16:18+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -53,7 +53,7 @@ msgstr "Nee"
 msgid "All"
 msgstr "Alle"
 
-#: symfexit/members/admin.py:102 symfexit/members/models.py:232
+#: symfexit/members/admin.py:102 symfexit/members/models.py:241
 msgid "local groups"
 msgstr "groepen"
 
@@ -327,28 +327,28 @@ msgstr "gebruiker"
 msgid "users"
 msgstr "gebruikers"
 
-#: symfexit/members/models.py:231
+#: symfexit/members/models.py:240
 msgid "local group"
 msgstr "groep"
 
-#: symfexit/members/models.py:238 symfexit/members/models.py:259
+#: symfexit/members/models.py:247 symfexit/members/models.py:268
 msgid "contact people"
 msgstr "contactpersonen"
 
-#: symfexit/members/models.py:242
+#: symfexit/members/models.py:251
 msgid "selectable"
 msgstr "selecteerbaar"
 
-#: symfexit/members/models.py:244
+#: symfexit/members/models.py:253
 msgid "Whether this group can be selected by new members signing up"
 msgstr ""
 "Of deze groep geselecteerd kan worder door nieuwe leden die zich inschrijven"
 
-#: symfexit/members/models.py:250
+#: symfexit/members/models.py:259
 msgid "work group"
 msgstr "werkgroep"
 
-#: symfexit/members/models.py:251
+#: symfexit/members/models.py:260
 msgid "work groups"
 msgstr "werkgroepen"
 

--- a/symfexit/members/models.py
+++ b/symfexit/members/models.py
@@ -188,6 +188,15 @@ class User(AbstractBaseUser, PermissionsMixin):
             return 0
         return self.credit_account.balance_cents()
 
+    @property
+    def local_group(self) -> LocalGroup | None:
+        return self.groups.filter(localgroup__isnull=False).first()
+
+    @property
+    def local_group_name(self) -> str | None:
+        local_group = self.local_group
+        return local_group.name if local_group else None
+
     def set_staff_rights(self) -> bool:
         # Add/remove user to contact person permission group
         contact_person_group = WellKnownPermissionGroup.get_or_create(

--- a/symfexit/root/export/databuilder.py
+++ b/symfexit/root/export/databuilder.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 from django.core.exceptions import FieldDoesNotExist
 from django.db import models
+from django.db.models import Manager
 from django.http import HttpResponse
 
 from symfexit.root.export.exporters._abstract_exporter import AbstractExporter
@@ -73,20 +74,34 @@ class ExportDataBuilder:
     ) -> list[list[str | int | float | bool | None]]:
         rows = []
         for obj in queryset:
-            rows.append(self.build_row(obj, export_fields))
+            rows.extend(self.flatten_rows(self.build_row(obj, export_fields)))
         return rows
 
-    def build_row(
-        self, obj: models.Model, export_fields: fields
-    ) -> list[str | int | float | bool | None]:
+    def flatten_rows(self, partial_row: list) -> list[list[str | int | float | bool | None]]:
+        for i, value in enumerate(partial_row):
+            if isinstance(value, list):
+                result = []
+                prefix = partial_row[:i]
+                suffix = partial_row[i + 1 :]
+                for sub_row in value:
+                    result.extend(self.flatten_rows(prefix + sub_row + suffix))
+                return result
+        return [partial_row]
+
+    def build_row(self, obj: models.Model | None, export_fields: fields) -> list:
         row = []
         for field in export_fields:
             value = None
-            # recursively build nested fields
-            if isinstance(field, tuple) and isinstance(field[1], list):  # field with model
+            if isinstance(field, tuple) and isinstance(field[1], list):
                 attr, config = field
                 if obj is not None:
                     value = getattr(obj, attr)
+                if isinstance(value, Manager):
+                    objects = list(value.all())
+                    if objects:
+                        row.append([self.build_row(sub_obj, config) for sub_obj in objects])
+                        continue
+                    value = None
                 row.extend(self.build_row(value, config))
                 continue
 

--- a/symfexit/root/tests.py
+++ b/symfexit/root/tests.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 
 from django.core.exceptions import FieldDoesNotExist
 from django.db import models as django_models
+from django.db.models import Manager
 from django.test import SimpleTestCase
 from django.utils.functional import SimpleLazyObject
 
@@ -31,6 +32,12 @@ def make_obj(**attrs):
     for k, v in attrs.items():
         setattr(obj, k, v)
     return obj
+
+
+def make_manager(*objects):
+    manager = MagicMock(spec=Manager)
+    manager.all.return_value = list(objects)
+    return manager
 
 
 class BuildHeaderTest(SimpleTestCase):
@@ -154,6 +161,14 @@ class BuildRowsTest(SimpleTestCase):
         obj = make_obj(b=None)
         model = make_model()
         export_fields: fields = [("b", [("c", ["attr1", "attr2"])])]
+        builder = ExportDataBuilder(export_fields, [obj], model)
+        self.assertEqual(builder.build_rows([obj], export_fields), [[None, None]])
+
+    def test_chained_to_many_with_empty_middle_produces_none_for_all_nested_fields(self):
+        # A → (many) B (empty) → (many) C: C's fields must still appear as None so the row length matches the header
+        obj = make_obj(bs=make_manager())
+        model = make_model()
+        export_fields: fields = [("bs", [("cs", ["attr1", "attr2"])])]
         builder = ExportDataBuilder(export_fields, [obj], model)
         self.assertEqual(builder.build_rows([obj], export_fields), [[None, None]])
 


### PR DESCRIPTION
1. Previous export mixin is added to admin
2. Add to many relation and set fields to get from this model

Also flattens rows.
Example:
To get a list of all attendees for an event: instead of a single row per event, the export now duplicates the event row for each attendee.

https://github.com/roodjong/symfexit/issues/277